### PR TITLE
Add script to look for all methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ aggregate.csv  Multisets.csv
 Process a module (check stability of all of its methods) in a Julia session:
 
 ``` julia
-checkModule(MyModule)
+checkModule(MyModule; extra_modules = Module[])
 ```
 
 - Assumes: `MyModule` is loaded.
 - Effects: in the current directory creates:
   - `MyModule.csv` with raw results of analysis;
   - `MyModule-agg.txt` with aggregate stats (possibly, for further analysis).
+
+The `extra_modules` parameter can be used to extend the search to detect external method definitions. By default, it is an empty array, in which case we look for functions just in `MyModule`. If non-empty, we also process functions from each of the extra modules and filter their methods to only those defined in `MyModule`. This approach catches cases when methods are added to external functions, e.g. `Base.hash(x::MyType, h::Uint) = ...`.
+
+To discover all methods from a module, we need to check the module itself and also all of its transitive dependencies. However, it's not trivial to get this list of modules, so a good approximation is to pass `Base.loaded_modules_array()` as the extra modules argument. This will return all the modules loaded currently in the julia session (including `Base`, `Core`, `MyModule`, and all of `MyModule`'s transitive dependencies); any other modules that also happen to be loaded are included as well, but this doesn't seem to affect performace much.
 
 A (possibly empty) set of `agg`-files can be turned into a single CSV via calling
 `scripts/aggregate.sh`. For just one file, it only adds the heading. The result

--- a/scripts/Project.toml
+++ b/scripts/Project.toml
@@ -1,3 +1,0 @@
-[deps]
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/StabilityCheck.jl
+++ b/src/StabilityCheck.jl
@@ -5,7 +5,7 @@ module StabilityCheck
 #
 
 export @stable, @stable!, @stable!_nop,
-    is_stable_method, is_stable_function, is_stable_module, is_stable_moduleb,
+    is_stable_method, is_stable_module, is_stable_moduleb,
     check_all_stable,
     convert,
     typesDB,
@@ -46,65 +46,44 @@ include("annotations.jl")
 #
 
 #
-# is_stable_module : Module, SearchCfg -> IO StCheckResults
+# is_stable_module : Module, SearchCfg; Vector{Module} -> IO StCheckResults
 #
-# Check all(*) function definitions in the module for stability.
-# Relies on `is_stable_function`.
+# Check all(*) method definitions in the module
+# (also look for all functions in extra_modules) for stability.
 # (*) "all" can mean all or exported; cf. `SearchCfg`'s  `exported_names_only`.
 #
-is_stable_module(mod::Module, scfg :: SearchCfg = default_scfg) :: StCheckResults =
-    is_stable_module_aux(mod, mod, Set{Module}(), scfg)
+# Notes: Constructors and Functors are currently ignored
+is_stable_module(mod::Module, scfg :: SearchCfg = default_scfg; extra_modules :: Vector{Module} = Module[]) :: StCheckResults = begin
+    @debug "is_stable_module($mod)" extra_modules
 
-# bool-returning version of the above
-is_stable_moduleb(mod::Module, scfg :: SearchCfg = default_scfg) :: Bool =
-    convert(Bool, is_stable_module(mod, scfg))
-
-# Auxiliary recursive implementation of `is_stable_module`. It gets two extra arguments:
-# - root is the toplevel module that we process; we only recurse into modules that are enclosed in root
-# - seen is a cache of modules we already processed; this prevents processing modules multiple times
-is_stable_module_aux(mod::Module, root::Module, seen::Set{Module}, scfg::SearchCfg) :: StCheckResults = begin
-    @debug "is_stable_module($mod)"
-    push!(seen, mod)
-    res = []
-    ns = names(mod; all=!scfg.exported_names_only, imported=true)
-    @debug "number of members in $mod: $(length(ns))"
-    for sym in ns
-        @debug "is_stable_module($mod): check symbol $sym"
-        try
-            evsym = getproperty(mod, sym)
-
-            # recurse into submodules
-            if evsym isa Module && !(evsym in seen) && is_module_nested(evsym, root)
-                @debug "is_stable_module($mod): found module $sym"
-                append!(res, is_stable_module_aux(evsym, root, seen, scfg))
-                continue
+    functions_found = Dict{Module,Set{OpaqueFunction}}()
+    modules_visited = Set{Module}([Main])
+    for m in Iterators.flatten(([mod], extra_modules))
+        discover_functions(m, m, scfg, modules_visited, get!(functions_found, m, Set{OpaqueFunction}()))
             end
 
-            # not interested in non-functional symbols
-            isa(evsym, Function) || continue
-
-            # not interested in special functions
-            special_syms = [ :include, :eval ]
-            (sym in special_syms) && continue
-
-            append!(res,
-                    map(m -> MethStCheck(m, is_stable_method(m, scfg)),
-                        our_methods_of_function(evsym, mod)))
+    result = StCheckResults()
+    for f in Set(Iterators.flatten(values(functions_found)))
+        for m in methods(f)
+            try
+                is_module_nested(m.module, mod) &&
+                    push!(result, MethStCheck(m, is_stable_method(m, scfg)))
         catch e
-            if e isa UndefVarError
-                @warn "Module $mod exports symbol $sym but it's undefined"
-                # showerror(stdout, e)
-                # not our problem, so proceed as usual
-            elseif e isa CantSplitMethod
-                @warn "Can't process method with no canonical instance:\n$m"
+                if e isa CantSplitMethod
+                    @warn "Can't process method with no canonical instance: $(e.m)."
                 # cf. comment in `split_method`
             else
                 throw(e)
             end
         end
     end
-    return res
+    end
+    return result
 end
+
+# bool-returning version of the above
+is_stable_moduleb(mod::Module, scfg :: SearchCfg = default_scfg; extra_modules :: Vector{Module} = Module[]) :: Bool =
+    convert(Bool, is_stable_module(mod, scfg; extra_modules))
 
 #
 # is_stable_method : Method, SearchCfg -> StCheck
@@ -124,7 +103,7 @@ is_stable_method(m::Method, scfg :: SearchCfg = default_scfg) :: StCheck = begin
             (scfg.typesDBcfg.types_db = typesDB())
     end
 
-    # Slpit method into signature and the corresponding function object
+    # Split method into signature and the corresponding function object
     sm = split_method(m)
     sm isa GenericMethod && return sm
     (func, sig_types) = sm

--- a/src/report.jl
+++ b/src/report.jl
@@ -121,8 +121,15 @@ aggregateStats(mcs::StCheckResults) :: AgStats = AgStats(
 # ----------------------------------------
 
 # checkModule :: Module, Path; String, Vector{Module} -> IO ()
-# Check stability in the given module (and also look for functions
-# in the extra_modules), store results under the given path
+# Check stability in the given module, store results under the given path
+#
+# The `extra_modules` parameter can be used to include functions that are bound in these modules and is needed because a module can add methods to external functions without also
+# importing them into its scope. For example, when a module `m` contains `Base.push!(x::MyVec, e) = ...` without importing `push!`, then `names(m)` does not include `push!`.
+# However, `names(Base)` does, and we can then filter only the methods that originate in `m`.
+#
+# To make sure we find all methods from `m`, `extra_modules` has to contain all the transitive dependencies of `m`, as well as `Base` and `Core` (which are always imported by default).
+# One simple over-approximation is to use `Base.loaded_modules_array()`.
+#
 # Effects:
 #   1. Module.csv with detailed, user-friendly results
 #   2. Module-agg.txt with aggregate results

--- a/src/report.jl
+++ b/src/report.jl
@@ -120,13 +120,14 @@ aggregateStats(mcs::StCheckResults) :: AgStats = AgStats(
 #
 # ----------------------------------------
 
-# checkModule :: Module, Path -> IO ()
-# Check stability in the given module, store results under the given path
+# checkModule :: Module, Path; String, Vector{Module} -> IO ()
+# Check stability in the given module (and also look for functions
+# in the extra_modules), store results under the given path
 # Effects:
 #   1. Module.csv with detailed, user-friendly results
 #   2. Module-agg.txt with aggregate results
-checkModule(m::Module, out::String="."; pkg::String="$m")= begin
-    checkRes = is_stable_module(m)
+checkModule(m::Module, out::String="."; pkg::String="$m", extra_modules::Vector{Module}=Module[]) = begin
+    checkRes = is_stable_module(m; extra_modules)
 
     # raw, to allow load it back up for debugging purposes
     # CSV.write(joinpath(out, "$m-raw.csv"), checkRes)

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,7 +26,7 @@ struct TooManyInst      <: SkippedUnionAlls
 end
 
 #
-#       Core Hierarchy: possible answers to a stability check querry
+#       Core Hierarchy: possible answers to a stability check query
 #
 abstract type StCheck end
 struct Stb <: StCheck         # hooary, we're stable


### PR DESCRIPTION
Putting this here for discussion.

This should go over a given project and all its dependencies, and find all methods the project defines.
Note, it also looks for direct definitions in external modules, eg. `Base.push!() = 1`.

Basically, it enumerates all top-level modules of packages reachable through the dependency graph (including `Base` as a special case), and looks for all functions in each module (also recursively in submodules).
Then it gets each function's method table, and filters methods coming from the project (implemented as a subdirectory check as of now)