### PR TITLE
Support for Unions

### DIFF
--- a/src/enumeration.jl
+++ b/src/enumeration.jl
@@ -102,6 +102,8 @@ generate_subtypes(ts1::Vector, scfg :: SearchCfg) = begin
             []
         elseif t == Any # if Any got here, we're asked to sample
             scfg.typesDBcfg.types_db
+        elseif is_concrete_type(t)
+            [t]
         else
             subtypes(t)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,9 @@ sum_top(v, t) = begin
     res
 end
 
+stable_funion(x::Bool, y::Union{TwoSubtypes, Bool}) = !x
+unstable_funion(x::Bool, y::Union{TwoSubtypes, Bool}) = if x 1 else "" end
+
 # Note: generic methods
 # We don't handle generic methods yet (#9)
 # rational_plusi(a::Rational{T}, b::Rational{T}) where T <: Integer = a + b
@@ -124,6 +127,17 @@ end
     #@test isa(is_stable_method((@which rational_plusi(1//1,1//1)), SearchCfg(abstract_args=true)), Stb)
 
     @test isa(is_stable_method((@which add1r(1.0 + 1.0im)), SearchCfg(abstract_args=true)) , Stb)
+end
+
+@testset "Unions                         " begin
+    res = is_stable_method(@which stable_funion(true, true))
+    @test res isa Stb
+    res = is_stable_method(@which unstable_funion(true, true))
+    @test res isa Uns &&
+        length(res.fails) == 3 &&
+        [Bool, SubtypeA] in res.fails &&
+        [Bool, SubtypeB] in res.fails &&
+        [Bool, Bool] in res.fails
 end
 
 @testset "Special (Any, Varargs, Generic)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,10 @@ add1n(x :: Number) = x + one(x)
 add1r(x :: Complex{T} where T <: AbstractFloat) = x + one(x)
 
 trivial_unstable(x::Int) = x > 0 ? 0 : "0"
+abstract type TwoSubtypes end
+struct SubtypeA <: TwoSubtypes end
+struct SubtypeB <: TwoSubtypes end
+trivial_unstable2(x::Bool, y::TwoSubtypes) = x ? y : ""
 
 plus2i(x :: Integer, y :: Integer) = x + y
 plus2n(x :: Number, y :: Number) = x + y
@@ -105,8 +109,14 @@ end
 end
 
 @testset "Simple unstable                " begin
-    @test isa(is_stable_method(@which add1n(1)),      Uns)
-    @test isa(is_stable_method(@which plus2n(1,1)),   Uns)
+    @test isa(is_stable_method(@which add1n(1)),                   Uns)
+    @test isa(is_stable_method(@which plus2n(1,1)),                Uns)
+    @test isa(is_stable_method(@which trivial_unstable(1)),        Uns)
+    res = is_stable_method(@which trivial_unstable2(true, SubtypeA()))
+    @test res isa Uns &&
+        length(res.fails) == 2 &&
+        [Bool, SubtypeA] in res.fails &&
+        [Bool, SubtypeB] in res.fails
 
     # cf. Note: generic methods
     # Alos, this used to fail when abstract instantiations are ON

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,7 +64,7 @@ struct SubtypeB <: TwoSubtypes end
 trivial_unstable2(x::Bool, y::TwoSubtypes) = x ? y : ""
 
 plus2i(x :: Integer, y :: Integer) = x + y
-plus2n(x :: Number, y :: Number) = x + y
+plus2n(x :: Real, y :: Real) = x + y
 
 sum_top(v, t) = begin
     res = 0 # zero(eltype(v))


### PR DESCRIPTION
This works by looking for unions in the currently processed list of types, and if there are any, peel the first type of the first one. We then replace the union in the current list with just the peeled type, and push a new list to the worklist that contains the rest of the Union