### PR TITLE
Trace type stability checks we do

### DIFF
--- a/src/StabilityCheck.jl
+++ b/src/StabilityCheck.jl
@@ -126,8 +126,7 @@ is_stable_method(m::Method, scfg :: SearchCfg = default_scfg) :: StCheck = begin
 
     # trace TS checks and store to a file
     if scfg.trace_checks
-        mkpath("checks")
-        fchecks = open("checks/$(m.name)", "w")
+        fchecks = open("checks", "a")
     end
 
     # preemptively load types DB if available: we may need to sample
@@ -150,7 +149,7 @@ is_stable_method(m::Method, scfg :: SearchCfg = default_scfg) :: StCheck = begin
     @debug "is_stable_method: check against signature (2a)"
     try
         scfg.trace_checks &&
-            println(fchecks, sig_types)
+            print_check(fchecks, m, sig_types)
         if is_stable_call(func, sig_types)
             scfg.trace_checks &&
                 close(fchecks)
@@ -200,7 +199,7 @@ is_stable_method(m::Method, scfg :: SearchCfg = default_scfg) :: StCheck = begin
         # the actual stability check
         try
             scfg.trace_checks &&
-                println(fchecks, ts)
+                print_check(fchecks, m, ts)
             if ! is_stable_call(func, ts)
                 push!(unst, ts)
                 if scfg.failfast

--- a/src/StabilityCheck.jl
+++ b/src/StabilityCheck.jl
@@ -147,18 +147,14 @@ is_stable_method(m::Method, scfg :: SearchCfg = default_scfg) :: StCheck = begin
     # Step 2a: run type inference with the input type even if abstract
     #          and party if we're concrete
     @debug "is_stable_method: check against signature (2a)"
-    try
-        scfg.trace_checks &&
-            print_check(fchecks, m, sig_types)
-        if is_stable_call(func, sig_types)
-            scfg.trace_checks &&
-                close(fchecks)
-            return Stb(1)
+    if ! scfg.trace_checks # we don't want the shortcut if we're in the tracing mode
+        try
+            if is_stable_call(func, sig_types)
+                return Stb(1)
+            end
+        catch e
+            return TcFail(sig_types, e)
         end
-    catch e
-        scfg.trace_checks &&
-            close(fchecks)
-        return TcFail(sig_types, e)
     end
 
     # Shortcut:

--- a/src/types.jl
+++ b/src/types.jl
@@ -122,6 +122,9 @@ Base.@kwdef struct SearchCfg
 
     typesDBcfg :: TypesDBCfg = TypesDBCfg()
 #   ^--- Parameters of the types DB.
+
+    trace_checks :: Bool = false
+#   ^-- create a file recording all type stability checks of a method
 end
 
 #
@@ -130,6 +133,8 @@ end
 default_scfg = SearchCfg()
 
 fast_scfg = SearchCfg(fuel=30)
+
+trace_scfg = SearchCfg(trace_checks=true)
 
 build_typesdb_scfg(inFile = intypesCsvFileDefault; sample_count :: Int = 100000) = begin
     tdbFull = typesDB(inFile)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -134,3 +134,12 @@ is_module_nested(m::Module, outer::Module) :: Bool = begin
         m = parentmodule(m)
     end
 end
+
+# Print type stability check in a form of pseudo-method declaration
+print_check(io, m::Method, @nospecialize(types)) = begin
+    print(io, "function $(m.name)(")
+    for t in types
+        print(io, "::$t")
+    end
+    println(io, ")")
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -138,8 +138,6 @@ end
 # Print type stability check in a form of pseudo-method declaration
 print_check(io, m::Method, @nospecialize(types)) = begin
     print(io, "function $(m.name)(")
-    for t in types
-        print(io, "::$t")
-    end
+    print(io, join(map(t->"::$t", types), ", "))
     println(io, ")")
 end


### PR DESCRIPTION
Store the checks in a `checks` file in the current dir.

The tracing mode is governed by a flag in the search config (`SearchCfg`). There's a default config with that flag on called `trace_scfg`. So, calling `is_stable_method((@which f(1)), trace_cfg)` should store the trace in the `./checks` file. 

Currently, the `./checks` file is opened in an append mode so that we can make several calls to `is_stable_method` and see all the checks. This has pros and cons in terms of usability...

The format of the `./checks` file is funny: its "pseudo method declarations". E.g. if we check `f` with input `Int`, we will produce `function f(::Int)` in the trace.

Perhaps, squash before merge.